### PR TITLE
Issue: 6 - Fix deprecated geolocation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Flask app to auto-detect local weather (temperature and chance of rain) based of
 
 ## Functionality
 
-Uses ipgetter to get a user's IP address and then used http://freegeoip.net to get more specific location information to pass into Weather API (https://darksky.net/dev/). Weather information (current temperature and % chance of rain) is returned based on the location associated with the IP.
+Get a user's IP address and then used http://ip-api.com/ to get more specific location information to pass into Weather API (https://darksky.net/dev/). Weather information (current temperature and % chance of rain) is returned based on the location associated with the IP.
 
 To work on this locally clone the repo, request and add an API key (locally) from darksky and then run `app.py`
 

--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ import urllib.request as ur
 import socket
 import requests
 import config
-import ipgetter
 
 app = Flask(__name__)
 
@@ -16,22 +15,31 @@ app = Flask(__name__)
 def location():
 
     # get the user's IP address
-    user_ip = ipgetter.myip()
-    #user_ip = gethostbyname(gethostname())
-    #user_ip = request.environ['REMOTE_ADDR']
+    user_ip = requests.get('http://ip.42.pl/raw').text
+
     print(user_ip)
 
     # get location information based off of IP address
-    url = 'http://freegeoip.net/json/'+user_ip
+    url = 'http://ip-api.com/json/#'+user_ip
     r = requests.get(url)
     js = r.json()
-    city = js['city']
-    state = js['region_name']
-    ip_coordinates = str(js['latitude']) + "," + str(js['longitude'])
+    status = js['status']
 
-    #pass the coordinates and city name to the route that gets weather info
-    return redirect(url_for('weather', ip_coordinates=ip_coordinates, city=city, state=state))
+    # if call is successful 
+    if status == 'success':
+        try:
+            city = js['city']
+            state = js['regionName']
+            ip_coordinates = str(js['lat']) + "," + str(js['lon'])
+
+            #pass the coordinates and city name to the route that gets weather info
+            return redirect(url_for('weather', ip_coordinates=ip_coordinates, city=city, state=state))
+        except KeyError:
+            return redirect(url_for('error_page'))
+    else:
+        return redirect(url_for('error_page'))
     # return "hah"
+
 @app.route('/weather/<ip_coordinates>/<city>/<state>')
 
 def weather(ip_coordinates, city, state):
@@ -66,5 +74,10 @@ def weather(ip_coordinates, city, state):
     weather_info = {'temperature' : temperature, 'rain' : rain_commentary}
     return render_template('weather.html',
                            location=location, weather_info=weather_info, weather_icon=weather_icon)
+
+@app.route('/404')
+def error_page():
+    return render_template('404.html')
+
 if __name__ == '__main__':
     app.run()

--- a/detect_location_weather.py
+++ b/detect_location_weather.py
@@ -7,7 +7,6 @@ import urllib.request as ur
 import socket
 import requests
 import config
-import ipgetter
 
 app = Flask(__name__)
 
@@ -22,17 +21,27 @@ def location():
     print(user_ip)
 
     # get location information based off of IP address
-    url = 'http://freegeoip.net/json/'+user_ip
+    url = 'http://ip-api.com/json/#'+user_ip
     r = requests.get(url)
     js = r.json()
-    city = js['city']
-    print("the city is " + city)
-    state = js['region_name']
-    ip_coordinates = str(js['latitude']) + "," + str(js['longitude'])
+    status = js['status']
 
-    #pass the coordinates and city name to the route that gets weather info
-    return redirect(url_for('weather', ip_coordinates=ip_coordinates, city=city, state=state))
+    # if call is successful 
+    if status == 'success':
+        try:
+            city = js['city']
+            state = js['regionName']
+            ip_coordinates = str(js['lat']) + "," + str(js['lon'])
+
+            #pass the coordinates and city name to the route that gets weather info
+            return redirect(url_for('weather', ip_coordinates=ip_coordinates, city=city, state=state))
+        except KeyError:
+            return redirect(url_for('error_page'))
+    else:
+        return redirect(url_for('error_page'))
     # return "hah"
+
+
 @app.route('/weather/<ip_coordinates>/<city>/<state>')
 
 def weather(ip_coordinates, city, state):
@@ -67,5 +76,10 @@ def weather(ip_coordinates, city, state):
     weather_info = {'temperature' : temperature, 'rain' : rain_commentary}
     return render_template('weather.html',
                            location=location, weather_info=weather_info, weather_icon=weather_icon)
+
+@app.route('/404')
+def error_page():
+    return render_template('404.html')
+
 if __name__ == '__main__':
     app.run()

--- a/static/css/error.css
+++ b/static/css/error.css
@@ -1,0 +1,23 @@
+body {
+    font-family: 'Roboto', sans-serif;
+    background-color: #e7ecec;
+    color: #01082f;
+    width: 50%;
+    text-align: center;
+    padding-top: 5em;
+    margin: auto;
+}
+
+.error-card {
+    /* Add shadows to create the "card" effect */
+    box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+    transition: 0.3s;
+    background-color: #b6ebef;
+    width: 60%;
+    margin: 20px auto;
+    padding: 20px;
+}
+
+.retry {
+    margin-top: 15px;
+}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>Oops!</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <link rel= "stylesheet" type= "text/css" href= "{{ url_for('static',filename='css/error.css') }}">
+  </head>
+  <body>
+
+    <div class="error-card">
+        Whoops! Something went wrong. <br> Feel free to create an issue! ❤️
+        <br>
+        <a href="/">
+            <button type="button" class="btn btn-dark retry">Retry</button>
+        </a>
+    </div>
+
+    <footer>Made by: Monica Powell | <a href="https://github.com/M0nica/flask_weather">View on GitHub</a> </footer>
+
+
+  </body>
+</html>


### PR DESCRIPTION
Fixes Issue# 6

The [http://freegeoip.net API](http://freegeoip.net/shutdown) that was used was shut down and replaced by newer api's. The most convenient alternative I could find was http://ip-api.com as they don't require you to create an account. Also instead of the server just responding with a failure, I made it return a 404 page. Also in the process, I worked on replacing the ipgetter library. However, I saw that 'byarnis' had already implemented a [fix](https://github.com/M0nica/flask_weather/pull/5). So at least that part from me could be ignored. Sorry for any confusion!

The 404 page:

![weather](https://user-images.githubusercontent.com/17018996/46781489-b960da00-ccd6-11e8-8d75-019720b601c6.PNG)
